### PR TITLE
Add missing target in FlattenedNodesObserver call

### DIFF
--- a/2.0/polymer-2-cheat-sheet.md
+++ b/2.0/polymer-2-cheat-sheet.md
@@ -349,8 +349,8 @@ And you want to be notified when nodes have been added/removed:
     /* ... */
     connectedCallback: function() {
       super.connectedCallback();
-      this._observer = new Polymer.FlattenedNodesObserver(function(info) {
-      // info is {addedNodes: [...], removedNodes: [...]}
+      this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
+        // info is {addedNodes: [...], removedNodes: [...]}
       });
     }
     disconnectedCallback: function() {


### PR DESCRIPTION
FlattenedNodesObserver's constructor takes 2 parameters : the target node and the callback function.